### PR TITLE
Don't report REFL026 when interface types is given

### DIFF
--- a/ReflectionAnalyzers.Tests/REFL026MissingDefaultConstructorTests/Valid.cs
+++ b/ReflectionAnalyzers.Tests/REFL026MissingDefaultConstructorTests/Valid.cs
@@ -149,5 +149,32 @@ namespace N
 
             RoslynAssert.Valid(Analyzer, Descriptor, code);
         }
+
+        [Test]
+        public static void WhenOnInterfaceTypes()
+        {
+            var code = @"
+namespace N
+{
+    using System;
+
+    public interface A { }
+
+    public class B : A
+    {
+        public B() { }
+    }
+
+    public class C
+    {
+        public C(A a)
+        {
+            var foo = (A?)Activator.CreateInstance(a.GetType());
+        }
+    }
+}";
+
+            RoslynAssert.Valid(Analyzer, Descriptor, code);
+        }
     }
 }

--- a/ReflectionAnalyzers/NodeAnalzers/ActivatorAnalyzer.cs
+++ b/ReflectionAnalyzers/NodeAnalzers/ActivatorAnalyzer.cs
@@ -104,6 +104,9 @@
 
         private static bool IsMissingDefaultConstructor(IMethodSymbol createInstance, InvocationExpressionSyntax invocation, INamedTypeSymbol createdType)
         {
+            if (createdType.TypeKind == TypeKind.Interface)
+                return false;
+
             if (createInstance.IsGenericMethod &&
                 !HasDefaultConstructor())
             {


### PR DESCRIPTION
There is a special case for REFL026 where it incorrectly reports when the user uses interfaceType.GetType(). It would probably be possible to support this use case by checking if the type being cast to has a default constructor, but I'm not familiar enough with analyzers to do that.

Instead, this pull-request makes sure the REFL026 does not report on that kind of code.

I've added a unit test that simulates the situation.